### PR TITLE
feat(media): add /files/media folder with auto-listing + helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run dev      # astro dev --host (local dev server, exposed on the network)
-npm run build    # astro build -> dist/
-npm run preview  # serve the production build locally
+npm run dev          # astro dev --host (local dev server, exposed on the network)
+npm run build        # astro build -> dist/
+npm run preview      # serve the production build locally
+npm run media -- <file> [more...]  # copy file(s) into public/media/ (see below)
 ```
 
 There is no test suite, linter, or formatter configured — `package.json` only wraps the Astro CLI. TypeScript runs in Astro's `strict` mode (`tsconfig.json` extends `astro/tsconfigs/strict`).
@@ -27,6 +28,8 @@ There is no test suite, linter, or formatter configured — `package.json` only 
 **Special notes shadow the dynamic route.** A note with a `component` field (e.g. `nurture`, `building-a-computer`) is rendered by a dedicated static `.astro` page at `src/pages/files/notes/<slug>.astro` instead of the generic `[slug].astro`. Astro prioritizes static routes over dynamic ones, so the static page wins. These pages still pull their intro prose from the matching `notes.ts` entry to keep a single source of truth.
 
 **The Jack game is a vendored Nand2Tetris simulator.** `src/lib/n2t-sim/` is the official web-ide VM/CPU/ALU/Jack-language simulator (vendored, plain `.js` + `.d.ts`). `src/components/Pages/JackGame/JackGame.astro` is a vanilla-JS island that: fetches `public/game/files.json` → fetches each `.vm` file → `VM.parse` → `Vm.buildFromFiles` → runs a `step()` loop, blitting the Hack screen memory to a `<canvas>` and mapping browser keys to Hack keycodes. To swap the game, replace the `.vm` files in `public/game/` and list them in `files.json` (entry point is `Sys.init` → `Main.main`). `STEPS_PER_FRAME` in that file is the speed knob. The game is keyboard-only and hidden on touch/small screens (a `matchMedia` check in the script mirrors the CSS media query).
+
+**The `media/` folder is auto-listed.** `public/media/` is a drop folder for shareable files. Anything placed there serves from the site root (`public/media/x.webp` → `/media/x.webp` — that's the shareable link) and is auto-listed at `/files/media` by `src/pages/files/media.astro`, which reads the directory with `fs` at build time — no manual list editing to add a file. `npm run media -- <file>` just copies files in. To publish, commit and deploy (main → prod). Keep this in-repo only while files stay small/infrequent; large or high-volume media should move to external storage (e.g. Cloudflare R2) and the index made data-driven.
 
 **Layout & globals.** Every page wraps content in `src/layouts/Layout.astro`, which sets meta/OG tags, loads global SCSS, mounts the Lenis smooth-scroll island (`SmoothScroll`), and injects Google Analytics via Partytown. The GA ID is hardcoded in `Layout.astro`.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev --host",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "media": "node scripts/add-media.mjs"
   },
   "dependencies": {
     "@astrojs/partytown": "^2.1.4",

--- a/scripts/add-media.mjs
+++ b/scripts/add-media.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Copies one or more files into public/media/ so they're served from the site
+// root at /media/<name> and auto-listed on /files/media.
+//
+// Usage: npm run media -- <file> [more files...]
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Read the site URL straight from the source of truth (without needing to parse
+// TypeScript) so the printed share links match the deployed domain.
+const legalInfo = fs.readFileSync(
+  path.join(process.cwd(), 'src/assets/data/legalInfo.ts'),
+  'utf8'
+)
+const WEBSITE_URL =
+  legalInfo.match(/WEBSITE_URL\s*=\s*['"]([^'"]+)['"]/)?.[1] ?? 'https://jesselind.com'
+
+const destDir = path.join(process.cwd(), 'public', 'media')
+
+const args = process.argv.slice(2)
+if (args.length === 0) {
+  console.error('Usage: npm run media -- <file> [more files...]')
+  process.exit(1)
+}
+
+fs.mkdirSync(destDir, { recursive: true })
+
+let copied = 0
+for (const src of args) {
+  if (!fs.existsSync(src) || !fs.statSync(src).isFile()) {
+    console.error(`✗ skipped (not a file): ${src}`)
+    continue
+  }
+  const base = path.basename(src)
+  const dest = path.join(destDir, base)
+  if (fs.existsSync(dest)) {
+    console.error(`✗ skipped (already in public/media/): ${base}`)
+    continue
+  }
+  fs.copyFileSync(src, dest)
+  console.log(`✓ public/media/${base}`)
+  console.log(`  share: ${WEBSITE_URL}/media/${base}`)
+  copied++
+}
+
+if (copied > 0) {
+  console.log(`\nAdded ${copied} file(s). Commit & deploy to publish them:`)
+  console.log('  git add public/media && git commit -m "media: add files" && git push')
+}

--- a/src/components/Pages/Files/Files.tsx
+++ b/src/components/Pages/Files/Files.tsx
@@ -11,6 +11,7 @@ const Files = () => {
   const folderLinks = [
     { name: 'notes/', src: '/files/notes' },
     { name: 'legal/', src: '/files/legal' },
+    { name: 'media/', src: '/files/media' },
   ]
 
   return (

--- a/src/pages/files/media.astro
+++ b/src/pages/files/media.astro
@@ -1,0 +1,40 @@
+---
+import DefaultFileList from '../../components/Common/DefaultFileList';
+import type { NavLinkType } from '../../components/Common/NavHeader/NavHeader';
+import type { FileLinkType } from '../../components/Common/FileList/FileList';
+import Layout from '../../layouts/Layout.astro';
+import fs from 'node:fs';
+import path from 'node:path';
+import '../../styles/global.scss';
+
+const navLinks: NavLinkType[] = [
+  { name: 'jesselind', src: '/' },
+  { name: 'files', src: '/files' },
+  { name: 'media', src: '/files/media' },
+]
+
+// Auto-listed at build time: every file dropped in public/media/ shows up here
+// and is shareable at /media/<filename>. No need to edit this file to add one.
+const mediaDir = path.join(process.cwd(), 'public/media')
+const assetLinks: FileLinkType[] = (fs.existsSync(mediaDir) ? fs.readdirSync(mediaDir) : [])
+  .filter((name) => !name.startsWith('.'))
+  .sort()
+  .map((name) => {
+    const ext = path.extname(name)
+    return {
+      name: path.basename(name, ext),
+      src: `/media/${name}`,
+      type: ext || undefined,
+    }
+  })
+
+// Optional hand-added rendered pages (real routes under /files/media/<slug>.astro)
+// can be appended here. Empty for now.
+const pageLinks: FileLinkType[] = []
+
+const fileLinks = [...assetLinks, ...pageLinks]
+---
+
+<Layout title="media/">
+  <DefaultFileList navLinks={navLinks} fileLinks={fileLinks} client:load />
+</Layout>


### PR DESCRIPTION
Adds a `media/` folder under `/files` for shareable files/images.

- `public/media/` drop folder; assets serve from the site root (`/media/<file>`) as stable share links
- `/files/media` auto-lists the folder at build time (no manual editing to add a file)
- `npm run media -- <file>` copies files into the folder and prints the share URL
- CLAUDE.md documents the convention