### PR TITLE
fix(media): per-item viewer page with breadcrumbs + back

### DIFF
--- a/src/components/Common/DefaultFileList/DefaultFileList.tsx
+++ b/src/components/Common/DefaultFileList/DefaultFileList.tsx
@@ -9,15 +9,17 @@ import type { NavLinkType } from '../NavHeader/NavHeader'
 const DefaultFileList = ({
   navLinks,
   fileLinks,
+  emptyMessage,
 }: {
   navLinks: NavLinkType[]
   fileLinks: FileLinkType[]
+  emptyMessage?: string
 }) => {
   return (
     <div className={`${styles.DefaultFileList} notes-style-page`}>
       <div className={`${styles.content} notes-content`}>
         <NavHeader links={navLinks} />
-        <FileList list={fileLinks} />
+        <FileList list={fileLinks} emptyMessage={emptyMessage} />
         <BackButton />
       </div>
     </div>

--- a/src/components/Common/FileList/FileList.tsx
+++ b/src/components/Common/FileList/FileList.tsx
@@ -8,7 +8,20 @@ export type FileLinkType = {
   type?: string
 }
 
-const FileList = ({ list }: { list: FileLinkType[] }) => {
+const FileList = ({
+  list,
+  emptyMessage,
+}: {
+  list: FileLinkType[]
+  emptyMessage?: string
+}) => {
+  if (list.length === 0 && emptyMessage) {
+    return (
+      <div className={`files-list`}>
+        <div className={`files-empty`}>{emptyMessage}</div>
+      </div>
+    )
+  }
   return (
     <div className={`files-list`}>
       {list.map((file, index, origArr) => (

--- a/src/pages/files/media.astro
+++ b/src/pages/files/media.astro
@@ -13,17 +13,19 @@ const navLinks: NavLinkType[] = [
   { name: 'media', src: '/files/media' },
 ]
 
-// Auto-listed at build time: every file dropped in public/media/ shows up here
-// and is shareable at /media/<filename>. No need to edit this file to add one.
+// Auto-listed at build time: every file dropped in public/media/ shows up here.
+// Each row links to its viewer page (/files/media/<name>) for consistent on-site
+// viewing with back navigation; the raw file stays shareable at /media/<filename>.
 const mediaDir = path.join(process.cwd(), 'public/media')
 const assetLinks: FileLinkType[] = (fs.existsSync(mediaDir) ? fs.readdirSync(mediaDir) : [])
   .filter((name) => !name.startsWith('.'))
   .sort()
   .map((name) => {
     const ext = path.extname(name)
+    const base = path.basename(name, ext)
     return {
-      name: path.basename(name, ext),
-      src: `/media/${name}`,
+      name: base,
+      src: `/files/media/${base}`,
       type: ext || undefined,
     }
   })
@@ -36,5 +38,10 @@ const fileLinks = [...assetLinks, ...pageLinks]
 ---
 
 <Layout title="media/">
-  <DefaultFileList navLinks={navLinks} fileLinks={fileLinks} client:load />
+  <DefaultFileList
+    navLinks={navLinks}
+    fileLinks={fileLinks}
+    emptyMessage="nothing here yet."
+    client:load
+  />
 </Layout>

--- a/src/pages/files/media/[slug].astro
+++ b/src/pages/files/media/[slug].astro
@@ -1,0 +1,83 @@
+---
+// Viewer page for a single media item. Mirrors the notes pages: breadcrumbs at
+// top, content in the centered note column, back link at the bottom. The raw
+// file still lives at /media/<file> (that's the shareable link); this page just
+// wraps it so on-site viewing is consistent and has back navigation.
+import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/global.scss';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function getStaticPaths() {
+  const mediaDir = path.join(process.cwd(), 'public/media');
+  const files = fs.existsSync(mediaDir)
+    ? fs.readdirSync(mediaDir).filter((name) => !name.startsWith('.'))
+    : [];
+  return files.map((file) => {
+    const ext = path.extname(file);
+    return {
+      params: { slug: path.basename(file, ext) },
+      props: { file, ext: ext.toLowerCase(), base: path.basename(file, ext) },
+    };
+  });
+}
+
+const { file, ext, base } = Astro.props;
+const src = `/media/${file}`;
+
+const kind = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.avif'].includes(ext)
+  ? 'image'
+  : ['.mp4', '.webm', '.mov', '.ogv'].includes(ext)
+    ? 'video'
+    : ['.mp3', '.wav', '.m4a', '.flac', '.ogg'].includes(ext)
+      ? 'audio'
+      : 'file';
+---
+
+<Layout title={`${base}${ext}`}>
+  <div class="notes-style-page">
+    <div class="notes-content">
+      <div class="nav-header">
+        <a href="/">jesselind</a> / <a href="/files">files</a> /
+        <a href="/files/media">media</a> / <i><a href="#">{base}</a></i>
+      </div>
+
+      <div class="media-view">
+        {kind === 'image' && <img src={src} alt={base} />}
+        {kind === 'video' && <video src={src} controls />}
+        {kind === 'audio' && <audio src={src} controls />}
+        {kind === 'file' && (
+          <a class="media-download" href={src} download>download {base}{ext}</a>
+        )}
+      </div>
+
+      <a class="media-original" href={src} target="_blank" rel="noopener noreferrer">
+        open original ↗
+      </a>
+
+      <a href="/files/media" class="notes-back-btn">../</a>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .media-view img,
+  .media-view video {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+  .media-view audio {
+    width: 100%;
+  }
+  .media-download {
+    text-decoration: underline;
+  }
+  .media-original {
+    font-size: 0.8rem;
+    font-weight: 200;
+    text-decoration: underline;
+    opacity: 0.7;
+  }
+</style>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -334,6 +334,12 @@ a[href^='tel'] {
   }
 }
 
+.files-empty {
+  font-size: $fs-xs;
+  font-weight: 200;
+  color: $secondary-text;
+}
+
 .project-images {
   display: grid;
   grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
Media list items now open an on-site viewer page (breadcrumbs + back link, image/video/audio embedded, else download link) instead of the bare raw file. Raw file stays shareable via the 'open original' link. Also adds an empty-state message for empty folders.